### PR TITLE
Build agains an updated GMT version

### DIFF
--- a/G/GMT/build_tarballs.jl
+++ b/G/GMT/build_tarballs.jl
@@ -3,14 +3,14 @@
 using BinaryBuilder, Pkg
 
 name = "GMT"
-version = v"6.4.0"
+version = v"6.4.1"
 GSHHG_VERSION="2.3.7"
 DCW_VERSION="2.1.1"
 
 # Collection of sources required to complete build
 sources = [
     GitSource("https://github.com/GenericMappingTools/gmt", 
-    "2414ba21f2acb722a0082c389e6517126092ba7c"),
+    "02d24df3402a20e23100920ede49285a9594e2a7"),
     
     ArchiveSource("https://github.com/GenericMappingTools/gshhg-gmt/releases/download/$GSHHG_VERSION/gshhg-gmt-$GSHHG_VERSION.tar.gz",
         "9bb1a956fca0718c083bef842e625797535a00ce81f175df08b042c2a92cfe7f"),
@@ -37,6 +37,7 @@ cmake -DCMAKE_INSTALL_PREFIX=${prefix} \
     -DHAVE___BUILTIN_BSWAP32=False \
     -DHAVE___BUILTIN_BSWAP64=False \
     -DGMT_ENABLE_OPENMP=True \
+    -DJULIA_GHOST_JLL=True \
     -DGSHHG_PATH=${WORKSPACE}/srcdir/${GSSHG} \
     -DGSHHG_VERSION=${GSHHG_VERSION_numeric} \
     -DDCW_PATH=${WORKSPACE}/srcdir/${DCW} \


### PR DESCRIPTION
There are some difficulties with finding ghostscript when it is called directly from the GMT binary and expects it to be found via path. A new change in the C lib adds a code path to seek the full gs path saved in a file stored in ~/.gmt